### PR TITLE
Fix duplicate username error

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -17,7 +17,7 @@ jobs:
       run: docker login -u ${{ secrets.DOCKER_USER }} -p  ${{ secrets.DOCKER_PASSWORD }}
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker build . --file api.Dockerfile --tag zlzforever/wildgoose-api:20260525.5
+      run: docker build . --file api.Dockerfile --tag zlzforever/wildgoose-api:20260525.6
     - name: Publish the Docker image
-      run: docker push zlzforever/wildgoose-api:20260525.5
+      run: docker push zlzforever/wildgoose-api:20260525.6
       

--- a/src/WildGoose.Application/Services/Admin/User/V10/UserAdminService.cs
+++ b/src/WildGoose.Application/Services/Admin/User/V10/UserAdminService.cs
@@ -228,6 +228,11 @@ public class UserAdminService(
                     : "-"
             };
         }
+        catch (WildGooseFriendlyException)
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
         catch (Exception e)
         {
             logger.LogError(e, "添加用户失败 UserId: {UserId}, UserName: {UserName}", user.Id, command.UserName);

--- a/src/WildGoose.Tests/UserAdminServiceTests.cs
+++ b/src/WildGoose.Tests/UserAdminServiceTests.cs
@@ -299,6 +299,44 @@ public class UserAdminServiceTests(WebApplicationFactoryFixture fixture) : BaseT
     }
 
     /// <summary>
+    /// 添加重复用户名应返回友好错误
+    /// </summary>
+    [Fact]
+    public async Task AddDuplicateUserNameShouldFailWithFriendlyMessage()
+    {
+        var scope = fixture.Instance.Services.CreateScope();
+        var session = scope.ServiceProvider.GetRequiredService<ISession>();
+        LoadSuperAdmin(session);
+
+        var userAdminService = scope.ServiceProvider.GetRequiredService<UserAdminService>();
+        var userName = CreateName();
+        await userAdminService.AddAsync(new AddUserCommand
+        {
+            UserName = userName,
+            Name = "测试用户",
+            Password = "Test@123456",
+            PhoneNumber = GenerateChinesePhoneNumber(),
+            Organizations = [],
+            Roles = []
+        });
+
+        var exception = await Assert.ThrowsAsync<WildGooseFriendlyException>(async () =>
+        {
+            await userAdminService.AddAsync(new AddUserCommand
+            {
+                UserName = userName,
+                Name = "重复用户",
+                Password = "Test@123456",
+                PhoneNumber = GenerateChinesePhoneNumber(),
+                Organizations = [],
+                Roles = []
+            });
+        });
+
+        Assert.Equal($"用户名 '{userName}' 已存在", exception.Message);
+    }
+
+    /// <summary>
     /// 添加用户时不能直接授予组织管理员角色
     /// </summary>
     [Fact]


### PR DESCRIPTION
fix(user-admin): 优化添加用户异常处理并补充测试用例

- 在添加用户过程中捕获 WildGooseFriendlyException 时回滚事务
- 保证友好异常时事务能正确回滚，防止数据不一致
- 新增重复用户名添加失败的单元测试，验证友好异常抛出和提示内容
- 通过测试覆盖保障异常处理逻辑的健壮性和错误信息的准确性